### PR TITLE
upd remove class

### DIFF
--- a/assets/endrock.js
+++ b/assets/endrock.js
@@ -161,6 +161,27 @@ const initBestSellerSection = () => {
   });
 }
 
+const removeSwiperClass = () => {
+  const customUpsell = document.querySelector(".my-floating-cart form.my-cart .custom_upsell");
+  if (customUpsell) {
+      customUpsell.classList.remove("swiper");
+      const containerElement = customUpsell.querySelector('div');
+      if (containerElement) {
+          containerElement.classList.remove("swiper-wrapper");
+          const slides = containerElement.querySelectorAll(".swiper-slide");
+          slides.forEach(element => {
+            element.classList.remove("swiper-slide");
+          });
+      }
+  }
+};
+
+window.addEventListener("ig:ready", () => { 
+  if(!(document.body.hasAttribute('data-variantb-upsell-carousel') || document.body.hasAttribute('data-variantc-upsell-carousel'))){
+    removeSwiperClass()
+  }
+});
+
 document.addEventListener('DOMContentLoaded', function() {
 
   // Start PDP Social Proof Data

--- a/snippets/slidecart-insert.liquid
+++ b/snippets/slidecart-insert.liquid
@@ -36,20 +36,6 @@
         }
       }
     }
-    const removeSwiperClass = () => {
-      const customUpsell = document.querySelector(".my-floating-cart form.my-cart .custom_upsell");
-      if (customUpsell) {
-          customUpsell.classList.remove("swiper");
-          const containerElement = customUpsell.querySelector('div');
-          if (containerElement) {
-              containerElement.classList.remove("swiper-wrapper");
-              const slides = containerElement.querySelectorAll(".swiper-slide");
-              slides.forEach(element => {
-                element.classList.remove("swiper-slide");
-              });
-          }
-      }
-    };
     const upsellSwiper = () => {
       const isMobile = window.innerWidth <= 768;
       if(isMobile){
@@ -84,8 +70,6 @@
         if(upsell){
           upsell.init();
         }
-      }else if(!(document.body.hasAttribute('data-variantb-upsell-carousel') || document.body.hasAttribute('data-variantc-upsell-carousel'))){
-        removeSwiperClass()
       }
     }  
   </script>


### PR DESCRIPTION
Side Cart: Upsell Carousel A/B/C [reference](https://app.clickup.com/t/86dr3t04v)

3 tipos de upsells en el side cart de Qure. La primera variante son los que actualmente están live en el sitio, la variante B son upsells con tarjetitas en forma más vertical con automatic swipe y la última variante C es con tarjetitas de producto horizontales igual con swipe automático. 

variant B: 
![image](https://github.com/Endrock/Qure-New/assets/22078616/e10e9210-d361-4979-a3b9-086059babec8)
![image](https://github.com/Endrock/Qure-New/assets/22078616/33a7c2a2-49e5-4885-ac7a-56034719d6ff)


variant C:
![image](https://github.com/Endrock/Qure-New/assets/22078616/10b05623-c2eb-4a75-8942-602d35c24ba5)
![image](https://github.com/Endrock/Qure-New/assets/22078616/cc4fcd27-76b4-479a-b633-bbc8afc12d1c)

