### PR TITLE
fix: added width to specific width to swiper-info-result

### DIFF
--- a/assets/endrock.css
+++ b/assets/endrock.css
@@ -579,6 +579,7 @@
             justify-content: center;
             align-items: center;
             .swiper-info-result{
+              width: 100%;
               .swiper-slide{
                 padding: 0 10px;
               }


### PR DESCRIPTION
# Task name - PDP carousel swiper fix - no tickect
---
## Type of pull request
- [ ] New Feature
- [x] Bugfixes
- [ ] Release
- [ ] Cleanup
- [ ] Other (adjustment)

### Description:
- A specific width value was specified to prevent the swiper from overflowing.

### Commits
[fix: added width to specific width to swiper-info-result](https://github.com/Endrock/Qure-New/commit/07a9ce98b06b288eee33a9c6512fd34d01ccb200)