### PR TITLE
feature/mi-lp-buy-block-upsell-price-per-item --stg

### DIFF
--- a/snippets/pdm-popup-upsell-landing.liquid
+++ b/snippets/pdm-popup-upsell-landing.liquid
@@ -41,6 +41,7 @@
         assign data_product_discount_percent = data_product.metafields.custom.popup_discount
         assign total_product_discount = data_product_price | times: data_product_discount_percent | floor
         assign monthly_price = data_product.price | minus: total_product_discount | floor
+        assign unit_price = monthly_price | divided_by: 6.00 | money_without_trailing_zeros
       %}
 
       <div class="popupsell-card" data-product-id="{{ data_product.id }}">
@@ -81,7 +82,11 @@
           <div class="popupsell-card-content-valueprops">
             <div class="popupsell-card-content-valueprops-info">
               <p>{{ data.upsell_valueprops_title }}</p>
-              {{ data.upsell_valueprops_content | metafield_tag | replace: '(check)', check_icon }}
+              {{ data.upsell_valueprops_content 
+                | metafield_tag 
+                | replace: '(check)', check_icon
+                | replace: '(unit_price)', unit_price
+              }}
             </div>
             <div class="popupsell-card-content-valueprops-footer">
               <p>{{ data.upsell_valueprops_footer }}</p>


### PR DESCRIPTION
# QR - MI LP Buy Block Upsells AB test - [Reference](https://app.clickup.com/t/86dve4r1m)

## Type of pull request
- [x] New Feature
- [ ] Bugfixes
- [ ] Release
- [ ] Cleanup
- [ ] Other (You must specify)

## Work Done

**Description**

A replace function is added so that when the rich text is used, it replaces the text with the price that each item should have. Text to replace: `price_unit`.

**File**

`snippets/pdm-popup-upsell-landing.liquid`

## Preview link
prev
https://qureskincare.com/?_ab=0&_fd=0&_sc=1&preview_theme_id=146953994479

intelligems
[https://www.qureskincare.com?ig-preview=8e2ff30b-36a4-4593-b9c8-875b6147d7c0](https://www.qureskincare.com/?ig-preview=8e2ff30b-36a4-4593-b9c8-875b6147d7c0)