### PR TITLE
Release: Face Serum + MI Patches Upsell Pop up (push-live)

### DIFF
--- a/assets/_pdm_product-upgrade-popup.js
+++ b/assets/_pdm_product-upgrade-popup.js
@@ -48,7 +48,10 @@ function handleDeclineOrClose(popup, overlay) {
     if (variant && popup && overlay) { 
       selector.addEventListener("click", function () {
         // We capture the variantId of the clicked plan
-        pdmSelectedVariantId = variant.closest(parentClass).dataset.variantid;
+        const variantElement = variant.closest(parentClass)
+        if (!variantElement) return;
+        pdmSelectedVariantId = variantElement.dataset.variantid || variantElement.getAttribute('data-product_variant_id');
+        
         // Show pop up
         popup.classList.remove("hidden");
         overlay.classList.remove("hidden");
@@ -79,7 +82,8 @@ function handleDeclineOrClose(popup, overlay) {
   */
   function addUpgradeVariantToCart() {
     let variantSelected = document.querySelector('label[for="mBanner_2_month"]').closest(".planBlockTop");
-    const variantId = variantSelected.dataset.variantid; // Variante del 4 Month Supply
+    if (!variantSelected) return;
+    const variantId = variantSelected.dataset.variantid || variantSelected.getAttribute('data-product_variant_id');
   
     // Create an <a> element that simulates an Ajax cart add
     const ajaxLink = document.createElement("a");
@@ -102,7 +106,6 @@ function handleDeclineOrClose(popup, overlay) {
   
     const hasBodyAttribute = document.body.hasAttribute('data-popup-test');
 
-    //if (!hasBodyAttribute) return false;
     labelTwoMonth = document.querySelector('label[for="mBanner_1_month"]');
      popup = document.getElementById("pdm-popup");
      overlay = document.getElementById("pdm-popup-overlay");
@@ -147,8 +150,6 @@ function handleDeclineOrClose(popup, overlay) {
       initPopupUpgrade();
     }, 1000);
   });
-
-  //document.addEventListener('DOMContentLoaded', initPopupUpgrade)
 /**
  * ============================================
  * END - PDM UPGRADE POPUP LOGIC - FACE SERUM

--- a/assets/_pdm_product-upgrade-popup.js
+++ b/assets/_pdm_product-upgrade-popup.js
@@ -20,7 +20,6 @@
     let  closeBtn;
     let  buyNowOne;
     let  buyNowTwo;
-    let  buttonOffers;
     let  variantsOne;
     let  variantsTwo;
     let  buttonOfferOne;
@@ -45,7 +44,7 @@ function handleDeclineOrClose(popup, overlay) {
   overlay.classList.add("hidden");
 }
 
-   function openPopUpPromotion(variant, selector, overlay, popup, parentClass) {
+   function openPopUpPromotion(variant, selector, overlay, popup, parentClass) {  
     if (variant && popup && overlay) { 
       selector.addEventListener("click", function () {
         // We capture the variantId of the clicked plan
@@ -59,13 +58,12 @@ function handleDeclineOrClose(popup, overlay) {
     }
   }
 
-  function clickSelectors(selectorsVariant, popupBtn, buyNowBtn, nameInput) {
+  function clickSelectors(selectorsVariant, popupBtn, buyNowBtn) {
     selectorsVariant.forEach(selector => {
       selector.addEventListener("click", function () {
-        if (selector.id == nameInput) {
+        if (selector == selectorsVariant[selectorsVariant.length - 1]) {
           popupBtn.classList.remove('hidden');
           buyNowBtn.classList.add('hidden');
-      
         }else {
           popupBtn.classList.add('hidden');
           buyNowBtn.classList.remove('hidden');
@@ -101,51 +99,32 @@ function handleDeclineOrClose(popup, overlay) {
     setTimeout(() => ajaxLink.remove(), 500);
   }
 
-  function validPopupUpgrade() {
+  
     const hasBodyAttribute = document.body.hasAttribute('data-popup-test');
 
-    if (!hasBodyAttribute) return false;
-
-     labelTwoMonth = document.querySelector('label[for="mBanner_1_month"]');
-     labelOneMonth = document.querySelector('label[for="1_month"]');
+    //if (!hasBodyAttribute) return false;
+    labelTwoMonth = document.querySelector('label[for="mBanner_1_month"]');
      popup = document.getElementById("pdm-popup");
      overlay = document.getElementById("pdm-popup-overlay");
      decline = document.getElementById("pdm-decline");
      closeBtn = document.getElementById("pdm-popup-close");
-     buyNowOne = document.querySelector('.submit_btn_top');
-     buyNowTwo = document.querySelector('.submit_btn_down');
-     buttonOffers = document.querySelectorAll('.pdm-popup-btn');
-     variantsOne = document.querySelectorAll('input[name="mBanner_monthlyPlan"]');
-     variantsTwo = document.querySelectorAll('input[name="monthlyPlan"]');
-
-     buttonOfferOne = document.querySelector('.pdm-popup-btn-form');
-     buttonOfferTwo = document.querySelector('.pdm-popup-btn-image-form');  
-
-    if (!labelTwoMonth || 
-        !labelOneMonth || 
-        !popup || 
-        !overlay || 
-        !decline || 
-        !closeBtn || 
-        !buyNowOne || 
-        !buyNowTwo || 
-        !variantsOne || 
-        !variantsTwo || 
-        !buttonOfferOne || 
-        !buttonOfferTwo) {
-            return false;
-    }
-    return true
-  }
 
   function initPopupUpgrade () {
-    if (validPopupUpgrade ()) {
-    clickSelectors(variantsOne, buttonOfferOne, buyNowOne, 'mBanner_1_month')
-    clickSelectors(variantsTwo, buttonOfferTwo, buyNowTwo, '1_month')
+    let monthlyPlanElements = document.querySelectorAll('label.pdm-popup-months')
+    labelOneMonth = monthlyPlanElements[monthlyPlanElements.length - 1]
+    buyNowOne = document.querySelector('.submit_btn_top');
+    buyNowTwo = document.querySelector('.submit_btn_down');
+    buttonOfferOne = document.querySelector('.pdm-popup-btn-form');
+    buttonOfferTwo = document.querySelector('.pdm-popup-btn-image-form');
+    let monthlyVariantsOne = document.querySelectorAll('.planBlockTop label');
+    let monthlyVariantsTwo = document.querySelectorAll('.planBlockDown label');
+    clickSelectors(monthlyVariantsOne, buttonOfferOne, buyNowOne)
+    clickSelectors(monthlyVariantsTwo, buttonOfferTwo, buyNowTwo)
 
     // Show popup when 2 Month Supply or alternative option is clicked
     openPopUpPromotion(labelTwoMonth, buttonOfferOne, overlay, popup, ".planBlockTop");
     openPopUpPromotion(labelOneMonth, buttonOfferTwo, overlay, popup, ".planBlockDown");
+    
   
     // Close popup when clicking outside the popup (overlay)
     overlay?.addEventListener("click", function () {
@@ -161,10 +140,15 @@ function handleDeclineOrClose(popup, overlay) {
     closeBtn?.addEventListener("click", function () {
       handleDeclineOrClose(popup, overlay);
     });
-    }
   }
 
-  document.addEventListener('DOMContentLoaded', initPopupUpgrade)
+  document.addEventListener("DOMContentLoaded", (event) => {
+    setTimeout(() => {
+      initPopupUpgrade();
+    }, 1000);
+  });
+
+  //document.addEventListener('DOMContentLoaded', initPopupUpgrade)
 /**
  * ============================================
  * END - PDM UPGRADE POPUP LOGIC - FACE SERUM

--- a/sections/purchase-form-bundle.liquid
+++ b/sections/purchase-form-bundle.liquid
@@ -81,7 +81,11 @@
 
                     <div id="{{ section.settings.form_name }}-body-{{ section.id }}"></div>
 
-                    <a href="javascript:void(0)" class="btn btn-atc submit_btn_down mt-md-2 mt-4 productButtonObject" data-ajax-cart-request-button>
+                    <button type="button" class="btn btn-atc mt-md-2 mt-4 pdm-popup-btn hidden pdm-popup-btn-image-form">
+                                Buy Now
+                    </button>
+
+                    <a href="javascript:void(0)" class="btn btn-atc submit_btn_down mt-md-2 mt-4 pdm-popup-btn-image-form productButtonObject" data-ajax-cart-request-button>
                         <span class="btn_value">Buy Now</span>
                     </a>
 

--- a/snippets/purchase-form-bundle-product.liquid
+++ b/snippets/purchase-form-bundle-product.liquid
@@ -47,7 +47,6 @@
                             data-per="{{ data-per }}" 
                             data-image="{{ block.settings.image | img_url: 'master' }}" 
                             data-product_variant_id="{{ product_variant_id }}" 
-                            data-variantid="{{ product_variant_id }}"
                             data-soldout="{{ block.settings.soldout }}" 
                             data-preorder="{{ block.settings.preorder }}" 
                             data-type="{{ product_type }}">

--- a/snippets/purchase-form-bundle-product.liquid
+++ b/snippets/purchase-form-bundle-product.liquid
@@ -41,15 +41,17 @@
                             {% capture data-per %}Sold Out{% endcapture %}
                         {% endif %}
                         
-                        <div class="planBlock ignore" href="javascript:void(0)" 
+                        <div class="planBlock ignore planBlockDown" href="javascript:void(0)" 
                             data-tab="tab_{{ product_title_tag }}" 
                             data-pay="{{ product_price_divided | money_without_trailing_zeros }}" 
                             data-per="{{ data-per }}" 
                             data-image="{{ block.settings.image | img_url: 'master' }}" 
                             data-product_variant_id="{{ product_variant_id }}" 
+                            data-variantid="{{ product_variant_id }}"
                             data-soldout="{{ block.settings.soldout }}" 
                             data-preorder="{{ block.settings.preorder }}" 
                             data-type="{{ product_type }}">
+                            
 
                             {% if product_type == 3 %}
                                 <div class="plan_choosed">
@@ -57,7 +59,7 @@
                                 </div>                            
                             {% endif %}
                             <input type="radio" name="monthlyPlan_{{ section.settings.form_name }}" id="{{ section.id }}-{{ product_title_tag }}"{% if block.settings.preselected == true %} checked{% endif %}>
-                            <label class="monthly_plans" for="{{ section.id }}-{{ product_title_tag }}">
+                            <label class="monthly_plans pdm-popup-months" for="{{ section.id }}-{{ product_title_tag }}">
                                 <div class="plan_des">
                                     <div class="plan_hdr">
                                         <h3>{{ block.settings.heading }}</h3>

--- a/snippets/serums-allin-months-image-form.liquid
+++ b/snippets/serums-allin-months-image-form.liquid
@@ -79,7 +79,7 @@
                             <a class="planBlock planBlockDown new_block" data-variantid="{{ product_variant_id }}" href="month_1" data-tab="month_1" data-per="- {{ product.price | money_without_trailing_zeros }}"
                                 data-image="https://qureskincaredns.com/new/assets/all_in_one-1.webp">
                                 <input type="radio" name="monthlyPlan" id="1_month">
-                                <label class="monthly_plans" for="1_month" payment-price="{{ product_price_divided | money_without_trailing_zeros }}">
+                                <label class="monthly_plans pdm-popup-months" for="1_month" payment-price="{{ product_price_divided | money_without_trailing_zeros }}">
                                     <div class="plan_des">
                                         <div class="plan_hdr">
                                             <h3>2 Month Supply</h3>


### PR DESCRIPTION
# Task name - [QR - Face Serum + MI Patches Upsell Pop up](https://app.asana.com/1/22908445599079/project/1209342717228798/task/1209913330322404)

## Type of pull request
- [ ] New Feature
- [ ] Bugfixes
- [X] Release
- [ ] Cleanup
- [ ] Other (You must specify)

## Work Done
A new “upgrade” popup was implemented on the Face Serum and Micro-infusion Patches PDPs that only triggers when clicking “2 Month Supply” (Face Serum) or “1 Month Supply” (Patches), dynamically captures the selected plan’s variantId and displays the upgraded offer (4 Month Supply or 2 Month Supply), with a single shared handler for “No thanks” and the “X” button that adds the variant to the cart via AJAX and closes the popup.

## Screenshots
<img width="1325" alt="image" src="https://github.com/user-attachments/assets/c9927cb7-0031-4c86-bc92-59ecbf4fadb6" />


## Preview link
prev:
pdm-development:
https://qureskincare.com/products/face-serum?preview_theme_id=151125360879

